### PR TITLE
Fix error when empty array or object desirialized

### DIFF
--- a/jfes.c
+++ b/jfes.c
@@ -1133,8 +1133,9 @@ static jfes_status_t jfes_create_node(jfes_tokens_data_t *tokens_data, jfes_valu
             return jfes_no_memory;
         }
 
+        value->data.array_val->count = token->size;
+
         if (token->size > 0) {
-            value->data.array_val->count = token->size;
             value->data.array_val->items = (jfes_value_t**)jfes_malloc(token->size * sizeof(jfes_value_t*));
             if (!value->data.array_val->items) {
                 jfes_free(value->data.array_val);
@@ -1167,8 +1168,9 @@ static jfes_status_t jfes_create_node(jfes_tokens_data_t *tokens_data, jfes_valu
             return jfes_no_memory;
         }
 
+        value->data.object_val->count = token->size;
+
         if (token->size > 0) {
-            value->data.object_val->count = token->size;
             value->data.object_val->items = (jfes_object_map_t**)jfes_malloc(token->size * sizeof(jfes_object_map_t*));
             if (!value->data.object_val->items) {
                 jfes_free(value->data.object_val);


### PR DESCRIPTION
`count` field contain garbage when no elements in object/array. When we try free this value we may free unallocated memory. This pull request fix this.

Test code:

```c
jfes_value_t json;
jfes_parse_to_value(&jfes_config, "[]", 2, &json);
jfes_free_value(&jfes_config, &json);

jfes_value_t json;
jfes_parse_to_value(&jfes_config, "{}", 2, &json);
jfes_free_value(&jfes_config, &json);
```